### PR TITLE
Fix: install iproute2 in Docker container for host IP detection

### DIFF
--- a/scripts/visual-regression/Dockerfile
+++ b/scripts/visual-regression/Dockerfile
@@ -2,6 +2,9 @@ FROM mcr.microsoft.com/playwright:v1.59.1-jammy
 
 WORKDIR /app
 
+# Install iproute2 for host IP detection
+RUN apt-get update && apt-get install -y iproute2 && rm -rf /var/lib/apt/lists/*
+
 # Copy package files
 COPY scripts/visual-regression/package*.json ./scripts/visual-regression/
 RUN cd scripts/visual-regression && npm ci


### PR DESCRIPTION
The Playwright Docker image was missing the iproute2 package, causing the 'ip route' command to fail in docker-entrypoint.sh and preventing proper host IP detection.